### PR TITLE
Improve copy functionality and remove unnecessary async usage

### DIFF
--- a/resources/js/Hooks/useCopy.ts
+++ b/resources/js/Hooks/useCopy.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { useCopyToClipboard } from 'react-use'
 
 export function useCopy() {
@@ -6,13 +6,21 @@ export function useCopy() {
 
   const [copied, setCopied] = useState(false)
 
+  const timeoutRef = useRef<number | null>(null)
+
   function copyText(text: string) {
+    setCopied(false)
+
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current)
+    }
+
     copyToClipboard(text)
 
     if (state.value === text) {
       setCopied(true)
 
-      setTimeout(() => {
+      timeoutRef.current = window.setTimeout(() => {
         setCopied(false)
       }, 2000)
     }

--- a/resources/js/Pages/Account/Partials/TwoFactorForm.tsx
+++ b/resources/js/Pages/Account/Partials/TwoFactorForm.tsx
@@ -329,9 +329,9 @@ export function TwoFactorRecoveryCodesDialog({ show }: { show?: boolean }) {
     }
   }, [show])
 
-  async function handleCopyClick() {
+  function handleCopyClick() {
     if (recoveryCodes) {
-      await copyText(recoveryCodes.join('\n'))
+      copyText(recoveryCodes.join('\n'))
     }
   }
 


### PR DESCRIPTION
Refactored the `useCopy` hook to prevent multiple timeouts by using a `useRef` for tracking. Removed unnecessary `async` from `handleCopyClick` in `TwoFactorForm` to align with non-async `copyText()` function. These changes enhance reliability and clarity of the copy mechanism.